### PR TITLE
Enable beacon by default

### DIFF
--- a/aframe/src/index.js
+++ b/aframe/src/index.js
@@ -19,7 +19,7 @@ AFRAME.registerComponent('zesty-banner', {
     format: { type: 'string', oneOf: ['tall', 'wide', 'square'] },
     style: { type: 'string', default: defaultStyle, oneOf: ['standard', 'minimal'] },
     height: { type: 'float', default: 1 },
-    beacon: { type: 'boolean', default: false },
+    beacon: { type: 'boolean', default: true },
   },
 
   init: function() {
@@ -46,7 +46,7 @@ AFRAME.registerComponent('zesty-ad', {
     format: { type: 'string', oneOf: ['tall', 'wide', 'square'] },
     style: { type: 'string', default: defaultStyle, oneOf: ['standard', 'minimal'] },
     height: { type: 'float', default: 1 },
-    beacon: { type: 'boolean', default: false },
+    beacon: { type: 'boolean', default: true },
   },
 
   init: function() {

--- a/babylonjs/src/index.js
+++ b/babylonjs/src/index.js
@@ -8,7 +8,7 @@ import { version } from '../package.json';
 console.log('Zesty SDK Version: ', version);
 
 export default class ZestyBanner {
-  constructor(space, creator, network, format, style, height, scene, webXRExperienceHelper = null, beacon = false) {
+  constructor(space, creator, network, format, style, height, scene, webXRExperienceHelper = null, beacon = true) {
     const options = {
       height: height,
       width: formats[format].width * height

--- a/cryptovoxels/integration.js
+++ b/cryptovoxels/integration.js
@@ -100,7 +100,7 @@ const fetchNFT = async (space, creator, network = 'polygon') => {
             creator: "${creator}"
           }
         )
-        { 
+        {
           sellerNFTSetting {
             sellerAuctions (
               first: 5
@@ -150,12 +150,12 @@ const parseGraphResponse = async res => {
   let latestAuction = null;
   for (let i=0; i < sellerAuction.buyerCampaignsApproved.length; i++) {
     if (sellerAuction.buyerCampaignsApproved[i] && sellerAuction.buyerCampaigns.length > 0) {
-      latestAuction = sellerAuction.buyerCampaigns[i];           
+      latestAuction = sellerAuction.buyerCampaigns[i];
     }
   }
 
   if (latestAuction == null) {
-    return DEFAULT_DATAS 
+    return DEFAULT_DATAS
   }
 
   return latestAuction;
@@ -193,7 +193,7 @@ function sendOnLoadMetric(space) {
     }
 }
 
-async function loadBanner(space, creator, network, format, style, beacon = false) {
+async function loadBanner(space, creator, network, format, style, beacon = true) {
     let uri = null;
     const activeNFT = await fetchNFT(space, creator, network);
     if (activeNFT) uri = activeNFT.uri;

--- a/r3f/src/ZestyBanner.js
+++ b/r3f/src/ZestyBanner.js
@@ -21,7 +21,7 @@ export default function ZestyBanner(props) {
   const height = props.height ?? formats[format].height;
 
   const newStyle = props.style ?? defaultStyle;
-  const beacon = props.beacon ?? false;
+  const beacon = props.beacon ?? true;
 
   const loadBanner = async (space, creator, network, format, style) => {
     const activeNFT = await fetchNFT(space, creator, network);

--- a/threejs/src/index.js
+++ b/threejs/src/index.js
@@ -16,7 +16,7 @@ export default class ZestyBanner extends THREE.Mesh {
    * @param {Number} height Height of the banner
    * @param {THREE.WebGLRenderer} renderer Optional field to pass in the WebGLRenderer in a WebXR project
    */
-  constructor(space, creator, network, format, style, height, renderer = null, beacon = false) {
+  constructor(space, creator, network, format, style, height, renderer = null, beacon = true) {
     super();
     this.geometry = new THREE.PlaneGeometry(formats[format].width * height, height, 1, 1);
 

--- a/unity/Assets/ZestySDK/Scripts/Internal/Banner.cs
+++ b/unity/Assets/ZestySDK/Scripts/Internal/Banner.cs
@@ -13,13 +13,13 @@ namespace Zesty
             Polygon,
             Rinkeby
         }
-        
+
         public string space;
         public string creator;
         public Network network;
         public Formats.Types format;
         public Formats.Styles style;
-        public bool beaconEnabled = false;
+        public bool beaconEnabled = true;
 
         public Material[] placeholderMaterials = new Material[3];
         public Material runtimeBanner;

--- a/web/src/index.js
+++ b/web/src/index.js
@@ -16,7 +16,7 @@ class Zesty extends HTMLElement {
     this.width = '100%';
     this.height = '100%';
     this.shadow = this.attachShadow({ mode: 'open' });
-    this.beacon = false;
+    this.beacon = true;
 
     this.adjustHeightandWidth = this.adjustHeightandWidth.bind(this);
   }

--- a/wonderland/src/index.js
+++ b/wonderland/src/index.js
@@ -37,7 +37,7 @@ WL.registerComponent(
     /* Texture property to set after banner is loaded. Leave "auto" to detect from
      * known pipelines (Phong Opaque Textured, Flat Opaque Textured) */
     textureProperty: { type: WL.Type.String, default: 'auto' },
-    beacon: { type: WL.Type.Bool, default: false },
+    beacon: { type: WL.Type.Bool, default: true },
     /* Load IPFS gateways and default image uris at runtime, if false at build time */
     dynamicFormats: { type: WL.Type.Bool, default: true },
     /* Automatically creates a collision and cursor-target components, if there isn't one */
@@ -63,7 +63,7 @@ WL.registerComponent(
             collider: WL.Collider.Box,
             group: 0x2,
           });
-  
+
         this.cursorTarget =
           this.object.getComponent('cursor-target') || this.object.addComponent('cursor-target');
         this.cursorTarget.addClickFunction(this.onClick.bind(this));
@@ -72,7 +72,7 @@ WL.registerComponent(
 
       if(this.dynamicFormats) {
         let formatsScript = document.createElement('script');
-  
+
         formatsScript.onload = () => {
           this.formatsOverride = zestyFormats.formats;
           this.startLoading();


### PR DESCRIPTION
We should enable beacon by default since the data will be used to determine recommended price for auto-bid bot.

Also I think the Unity SDK is pointing to the old beacon endpoint. I'll make an update for that in the next PR.