### PR TITLE
Update parseGraphResponse and remove fleek

### DIFF
--- a/tests/utils/networking.test.js
+++ b/tests/utils/networking.test.js
@@ -50,6 +50,9 @@ const MOCK_GRAPH_RESPONSE_NO_BUYERCAMPAIGNS = {
             sellerAuctions: [
               {
                 buyerCampaigns: [],
+                buyerCampaignsIdList: [
+                  "1"
+                ],
                 buyerCampaignsApproved: [false],
               },
             ],
@@ -73,6 +76,9 @@ const MOCK_GRAPH_RESPONSE_BUYERCAMPAIGN_NOT_APPROVED = {
                     id: '0',
                     uri: '',
                   },
+                ],
+                buyerCampaignsIdList: [
+                  "1"
                 ],
                 buyerCampaignsApproved: [false],
               },
@@ -98,6 +104,9 @@ const MOCK_GRAPH_RESPONSE_VALID = {
                     uri: '',
                   },
                 ],
+                buyerCampaignsIdList: [
+                  "0"
+                ],
                 buyerCampaignsApproved: [true],
               },
             ],
@@ -107,6 +116,53 @@ const MOCK_GRAPH_RESPONSE_VALID = {
     },
   },
 };
+const MOCK_GRAPH_RESPONSE_CAMPAIGN_MANYTOMANY = {
+  status: '200',
+  data: {
+    data: {
+      tokenDatas: [
+        {
+          sellerNFTSetting: {
+            "sellerAuctions": [
+              {
+                "buyerCampaigns": [
+                  {
+                    "id": "1",
+                    "buyer": "0x8a4a755dfa17010cd92737a76f90353f4688578e",
+                    "uri": "testUri"
+                  },
+                  {
+                    "id": "2",
+                    "buyer": "0x8a4a755dfa17010cd92737a76f90353f4688578e",
+                    "uri": "testUri2"
+                  }
+                ],
+                "buyerCampaignsIdList": [
+                  "1",
+                  "2",
+                  "1",
+                  "2"
+                ],
+                "buyerCampaignsPending": [
+                  false,
+                  false,
+                  false,
+                  false
+                ],
+                "buyerCampaignsApproved": [
+                  false,
+                  false,
+                  false,
+                  true
+                ]
+              },
+            ]
+          }
+        }
+      ]
+    }
+  }
+}
 const URI_UNDEFINED = { uri: undefined };
 const VALID_AUCTION = { id: '0', uri: '' };
 const DEFAULT_URI_CONTENT = {
@@ -148,6 +204,13 @@ describe('parseGraphResponse', () => {
   });
   test('parseGraphResponse should return a valid auction if buyerCampaignsApproved is true', () => {
     expect(parseGraphResponse(MOCK_GRAPH_RESPONSE_VALID)).toStrictEqual(VALID_AUCTION);
+  });
+  test('parseGraphResponse should return campaign 2 in manytomany edge case', () => {
+    expect(parseGraphResponse(MOCK_GRAPH_RESPONSE_CAMPAIGN_MANYTOMANY)).toStrictEqual({
+      "id": "2",
+      "buyer": "0x8a4a755dfa17010cd92737a76f90353f4688578e",
+      "uri": "testUri2"
+    });
   });
 });
 

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -36,9 +36,8 @@ const parseProtocol = uri => {
 const getIPFSGateway = () => {
   const gateways = [
     { gateway: 'https://cloudflare-ipfs.com', weight: 35 },
-    { gateway: 'https://ipfs.fleek.co', weight: 35 },
-    { gateway: 'https://gateway.pinata.cloud', weight: 20 },
-    { gateway: 'https://dweb.link', weight: 10 }
+    { gateway: 'https://gateway.pinata.cloud', weight: 35 },
+    { gateway: 'https://dweb.link', weight: 30 }
   ];
 
   const weights = [];

--- a/utils/networking.js
+++ b/utils/networking.js
@@ -85,8 +85,12 @@ const parseGraphResponse = res => {
     return DEFAULT_DATAS 
   }
   let sellerAuctions = res.data.data.tokenDatas[0]?.sellerNFTSetting?.sellerAuctions;
-  let latestAuction = sellerAuctions[0]?.buyerCampaigns?.find((campaign, i) => {
-    if (sellerAuctions[0].buyerCampaignsApproved[i]) return campaign;
+  let latestAuction = null;
+  sellerAuctions?.[0]?.buyerCampaignsApproved?.find((campaign, i) => {
+    if (campaign) {
+      const campaignId = sellerAuctions[0].buyerCampaignsIdList[i]; // Graph stores as string, coerce to int
+      latestAuction = sellerAuctions[0].buyerCampaigns.find(campaign => campaign.id === campaignId)
+    }
   });
   
   if (latestAuction == null) {


### PR DESCRIPTION
- Update parseGraphResponse to handle campaigns using buyerCampaignsIdList
- Removed Fleek from IPFS gateways due to potential antivirus flagging concerns